### PR TITLE
Add CI to rebuild the dktk rserver image on push

### DIFF
--- a/.github/workflows/update_ccp_rserver.yml
+++ b/.github/workflows/update_ccp_rserver.yml
@@ -1,0 +1,12 @@
+name: Trigger DKTK RServer rebuild
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+    trigger-update:
+        runs-on: ubuntu-22.04
+
+        steps:
+          - run: curl -X POST --fail -F token=${{ secrets.R_SERVER_GITLAB_TOKEN }} -F ref=main https://git.verbis.dkfz.de/api/v4/projects/teiler%2Fdktk-rserver/trigger/pipeline


### PR DESCRIPTION
I will mail you the `R_SERVER_GITLAB_TOKEN` which you will need to add to the repository secrets in order for this to work.